### PR TITLE
STA AbsoluteUri path

### DIFF
--- a/DSCResources/VE_SFGateway/VE_SFGateway.ps1
+++ b/DSCResources/VE_SFGateway/VE_SFGateway.ps1
@@ -80,7 +80,7 @@ function Get-TargetResource {
             StasUseLoadBalancing = $gateway.StasUseLoadBalancing;
             StasBypassDuration = $gateway.StasBypassDuration.TotalSeconds;
             SubnetIPAddress = $gateway.IpAddress;
-            SecureTicketAuthorityUrls = @($gateway.SecureTicketAuthorityUrls.AbsoluteUri);
+            SecureTicketAuthorityUrls = @($gateway.SecureTicketAuthorityUrls.Url.AbsoluteUri);
             Ensure = if ($gateway) { 'Present' } else { 'Absent' };
         }
         return $targetResource;


### PR DESCRIPTION
Corrects the SecureTicketAuthorityUrls test problem in Storefront 3.12. The value was correctly reported by the Get-STFRoamingGateway call but not used during the test (Expected gateway property 'SecureTicketAuthorityUrls' to be 'http://srv-cxdc01.domain.net/scripts/ctxsta.dll', actual ''.)

The $gateway.SecureTicketAuthorityUrls.AbsoluteUri object doesn't exist (anymore ? ) Additionnal Storefront SDK version testing might be necessary if this object was available in a previous SDK version